### PR TITLE
Update dependencies to run in Elm 0.16.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "summary": "A linear algebra library for fast vector and matrix math",
     "repository": "https://github.com/johnpmayer/elm-linear-algebra.git",
     "license": "BSD3",
@@ -14,7 +14,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Here is the same pull request that I submitted to the upstream/original repo. It merely updates elm-package.json as needed to build with Elm 0.16.
